### PR TITLE
add O_SYNC flag when opening /dev/mem in servod.c

### DIFF
--- a/ServoBlaster/servod.c
+++ b/ServoBlaster/servod.c
@@ -232,7 +232,7 @@ mem_virt_to_phys(void *virt)
 static void *
 map_peripheral(uint32_t base, uint32_t len)
 {
-	int fd = open("/dev/mem", O_RDWR);
+	int fd = open("/dev/mem", O_RDWR | O_SYNC);
 	void * vaddr;
 
 	if (fd < 0)


### PR DESCRIPTION
The O_SYNC is often used when opening /dev/mem for access to BCM perihperals.  It opens the memory region without cpu caching, ensuring writes go directly to the peripheral's registers.

This may allow relaxing or removal of the delays in init_hardware().