### PR TITLE
PiFmDma fix for latest wheezy raspbian

### DIFF
--- a/PiFmDma/PiFmDma.c
+++ b/PiFmDma/PiFmDma.c
@@ -139,12 +139,10 @@
 #define GPFSEL0			(0x00/4)
 
 #define PLLFREQ			500000000	// PLLD is running at 500MHz
-//#define CARRIERFREQ		100000000	// Carrier frequency is 100MHz
+#define CARRIERFREQ		100000000	// Carrier frequency is 100MHz
 // The deviation specifies how wide the signal is. Use 25.0 for WBFM
 // (broadcast radio) and about 3.5 for NBFM (walkie-talkie style radio)
-//#define DEVIATION		25.0
-#define CARRIERFREQ		7040000	// Carrier frequency is 100MHz
-#define DEVIATION	 140.0	
+#define DEVIATION		25.0
 
 typedef struct {
 	uint32_t info, src, dst, length,


### PR DESCRIPTION
Hi Richard,
Thanks much for this excellent code. In the latest raspberry distribution I found that the code is no longer working. After a lot of debugging I finally found out the causes and fixed it. Here are my results. Can you incorporate it in your branch, please?
Guido
PE1NNZ

fix for PiFmDma runtime error in latest 2013-02-09-wheezy-raspbian.
first fix is a type cast for which the sign was not correct
second fix is addition of a bit mask to deal with a reserved bit which now suddenly seems to be 1 (which was assumed to be 0)
