### PR TITLE
fixed bug in MPU6050_6Axis_MotionApps20.h function uint8_t MPU6050::dmpI...

### DIFF
--- a/MPU6050-Pi-Demo/MPU6050_6Axis_MotionApps20.h
+++ b/MPU6050-Pi-Demo/MPU6050_6Axis_MotionApps20.h
@@ -414,7 +414,8 @@ uint8_t MPU6050::dmpInitialize() {
 
             printf("Current FIFO count=%d\n", fifoCount);
             DEBUG_PRINTLN(fifoCount);
-            getFIFOBytes(fifoBuffer, fifoCount);
+            if (fifoCount > 0)
+		getFIFOBytes(fifoBuffer, fifoCount);
 
             DEBUG_PRINTLN(F("Setting motion detection threshold to 2..."));
             setMotionDetectionThreshold(2);


### PR DESCRIPTION
...nitialize() which caused an i2c-read error in case of an empty fifoCount.
