### PR TITLE
Set idle-timeout to 0 in the init-script 

### DIFF
--- a/ServoBlaster/user/init-script
+++ b/ServoBlaster/user/init-script
@@ -13,7 +13,7 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 . /lib/init/vars.sh
 
-OPTS="--idle-timeout=2000"
+OPTS=""
 
 res=0
 


### PR DESCRIPTION
The README says that the default is 0, but it's not true.
This shouldn't be here :) (as per the README)
