### PR TITLE
Update servod.c

### DIFF
--- a/ServoBlaster/user/servod.c
+++ b/ServoBlaster/user/servod.c
@@ -972,7 +972,7 @@ get_model_and_revision(void)
 
 	if (strstr(modelstr, "BCM2708"))
 		board_model = 1;
-	else if (strstr(modelstr, "BCM2709") || strstr(modelstr, "BCM2835"))
+	else if (strstr(modelstr, "BCM2709") || strstr(modelstr, "BCM2835") || strstr(modelstr, "BCM2711"))
 		board_model = 2;
 	else
 		fatal("servod: Cannot parse the hardware name string\n");


### PR DESCRIPTION
Fix for "Cannot parse the hardware name string" issue.
Just added the BCM string value reported by the Pi 4.
